### PR TITLE
optimize setindex for StringVector

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -377,6 +377,10 @@ end
     _setindex!(arr, val, idx...)
 end
 
+@inline function Base.setindex!(arr::StringArray, val::STR, idx::Integer)
+    _setindex!(arr, val, idx)
+end
+
 function _setindex!(arr::StringArray, val::AbstractString, idx...)
     buffer = arr.buffer
     l = length(arr.buffer)
@@ -385,6 +389,21 @@ function _setindex!(arr::StringArray, val::AbstractString, idx...)
     arr.lengths[idx...] = sizeof(val)
     arr.offsets[idx...] = l
     val
+end
+
+function _setindex!(arr::StringArray, val::AbstractString, idx)
+    buffer = arr.buffer
+    l = length(arr.buffer)
+    resize!(buffer, l + sizeof(val))
+    unsafe_copy!(pointer(buffer, l+1), pointer(val,1), sizeof(val))
+    arr.lengths[idx] = sizeof(val)
+    arr.offsets[idx] = l
+    val
+end
+
+function _setindex!(arr::StringArray, val::Missing, idx)
+    arr.lengths[idx] = 0
+    arr.offsets[idx] = MISSING_OFFSET
 end
 
 function _setindex!(arr::StringArray, val::Missing, idx...)


### PR DESCRIPTION
Optimize `setindex` for `StringVector` by special casing 1-d implementation.

Without this patch:

```
julia> using WeakRefStrings, BenchmarkTools

julia> sv = StringVector{String}(convert(Vector{UInt8}, randstring(1024)), UInt64[1:10:1000;], ones(UInt32,100)*9);

julia> @btime for idx in 1:length(sv)
          sv[idx] = sv[idx]
       end;
  45.918 μs (601 allocations: 15.66 KiB)
```

With this:

```
julia> using WeakRefStrings, BenchmarkTools

julia> sv = StringVector{String}(convert(Vector{UInt8}, randstring(1024)), UInt64[1:10:1000;], ones(UInt32,100)*9);

julia> @btime for idx in 1:length(sv)
          sv[idx] = sv[idx]
       end;
  13.610 μs (201 allocations: 6.28 KiB)
```