### PR TITLE
optimize vcat of StringVector

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -449,4 +449,8 @@ function Base.permute!(arr::StringArray{String}, p::AbstractVector)
     arr
 end
 
+function Base.vcat(a::StringVector{T}, b::StringVector{T}) where T
+    StringVector{T}(vcat(a.buffer, b.buffer), vcat(a.offsets, b.offsets .+ length(a.buffer)), vcat(a.lengths, b.lengths))
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,4 +142,11 @@ end
         @test sv[1] == "JuliaDB"
         @test sv[end] == "TextParse"
     end
+
+    @testset "vcat" begin
+        sv1 = StringVector{String}(convert(Vector{UInt8}, randstring(1024)), UInt64[1:10:1000;], ones(UInt32,100)*9);
+        sv2 = StringVector{String}(convert(Vector{UInt8}, randstring(1024)), UInt64[1:10:1000;], ones(UInt32,100)*9);
+        sv3 = vcat(sv1, sv2)
+        @test length(sv3) == length(sv1) + length(sv2)
+    end
 end


### PR DESCRIPTION
faster `vcat` for `StringVector`, by direct `vcat` of internal fields and adjusting the offsets.