### PR TITLE
faster permute! for StringArray{String}

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -444,4 +444,9 @@ function Base.deleteat!(arr::StringVector, idx::Integer)
     arr
 end
 
+function Base.permute!(arr::StringArray{String}, p::AbstractVector)
+    permute!(convert(StringArray{WeakRefString{UInt8}}, arr), p)
+    arr
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,4 +135,11 @@ end
     @testset "test WeakRefString element type constructor" begin
         @test eltype(StringVector{WeakRefString}(1)) <: WeakRefString
     end
+
+    @testset "test permute!" begin
+        sv = StringVector(["TextParse", "TextParse", "JuliaDB", "TextParse", "TextParse", "TextParse", "TextParse", "JuliaDB", "JuliaDB"])
+        permute!(sv, reverse!([1:length(sv);]))
+        @test sv[1] == "JuliaDB"
+        @test sv[end] == "TextParse"
+    end
 end


### PR DESCRIPTION
Uses intermediary `StringArray{WeakRefString{UInt8}}` for speedup.

ref: https://github.com/JuliaComputing/IndexedTables.jl/pull/166