### PR TITLE
Add StringArray constructors that take undef

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -254,38 +254,19 @@ function Base.convert(::Type{<:StringArray{T}}, x::StringArray{<:STR,N}) where {
     StringArray{T, ndims(x)}(x.buffer, x.offsets, x.lengths)
 end
 
-# TODO Deprecate
-function StringArray{T, N}(dims::Tuple{Vararg{Integer}}) where {T,N}
-    StringArray{T,N}(similar(Vector{UInt8}, 0), fill(UNDEF_OFFSET, dims), fill(zero(UInt32), dims))
-end
-
 function StringArray{T, N}(::UndefInitializer, dims::Tuple{Vararg{Integer}}) where {T,N}
     StringArray{T,N}(similar(Vector{UInt8}, 0), fill(UNDEF_OFFSET, dims), fill(zero(UInt32), dims))
-end
-
-# TODO Deprecate
-function StringArray{T}(dims::Tuple{Vararg{Integer}}) where {T}
-    StringArray{T,length(dims)}(undef, dims)
 end
 
 function StringArray{T}(::UndefInitializer, dims::Tuple{Vararg{Integer}}) where {T}
     StringArray{T,length(dims)}(undef, dims)
 end
 
-# TODO Deprecate
-function StringArray(dims::Tuple{Vararg{Integer}})
-    StringArray{String}(undef, dims)
-end
-
 function StringArray(::UndefInitializer, dims::Tuple{Vararg{Integer}})
     StringArray{String}(undef, dims)
 end
 
-# TODO Deprecate
-(::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(dims)
 (::Type{S})(::UndefInitializer, dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(undef, dims)
-# TODO Deprecate
-(::Type{<:StringArray})(dims::Integer...) = StringArray{String,length(dims)}(dims)
 (::Type{<:StringArray})(::UndefInitializer, dims::Integer...) = StringArray{String,length(dims)}(undef, dims)
 
 function Base.convert(::Type{<:StringArray{T}}, arr::AbstractArray{<:STR, N}) where {T,N}
@@ -437,5 +418,14 @@ function Base.append!(a::StringVector{T}, b::AbstractVector) where T
         push!(a, x)
     end
 end
+
+# Deprecations
+
+Base.@deprecate StringArray{T, N}(dims::Tuple{Vararg{Integer}}) where {T,N} StringArray{T, N}(undef, dims)
+Base.@deprecate StringArray{T}(dims::Tuple{Vararg{Integer}}) where {T} StringArray{T}(undef, dims)
+Base.@deprecate StringArray(dims::Tuple{Vararg{Integer}}) StringArray(undef, dims)
+# TODO The following two deprecations don't work, but should be there
+# Base.@deprecate (::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} S(undef, dims)
+# Base.@deprecate (::Type{S})(dims::Integer...) where {S<:StringArray} S(dims...)
 
 end # module

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -254,23 +254,42 @@ function Base.convert(::Type{<:StringArray{T}}, x::StringArray{<:STR,N}) where {
     StringArray{T, ndims(x)}(x.buffer, x.offsets, x.lengths)
 end
 
+# TODO Deprecate
 function StringArray{T, N}(dims::Tuple{Vararg{Integer}}) where {T,N}
     StringArray{T,N}(similar(Vector{UInt8}, 0), fill(UNDEF_OFFSET, dims), fill(zero(UInt32), dims))
 end
 
+function StringArray{T, N}(::UndefInitializer, dims::Tuple{Vararg{Integer}}) where {T,N}
+    StringArray{T,N}(similar(Vector{UInt8}, 0), fill(UNDEF_OFFSET, dims), fill(zero(UInt32), dims))
+end
+
+# TODO Deprecate
 function StringArray{T}(dims::Tuple{Vararg{Integer}}) where {T}
-    StringArray{T,length(dims)}(dims)
+    StringArray{T,length(dims)}(undef, dims)
 end
 
+function StringArray{T}(::UndefInitializer, dims::Tuple{Vararg{Integer}}) where {T}
+    StringArray{T,length(dims)}(undef, dims)
+end
+
+# TODO Deprecate
 function StringArray(dims::Tuple{Vararg{Integer}})
-    StringArray{String}(dims)
+    StringArray{String}(undef, dims)
 end
 
+function StringArray(::UndefInitializer, dims::Tuple{Vararg{Integer}})
+    StringArray{String}(undef, dims)
+end
+
+# TODO Deprecate
 (::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(dims)
+(::Type{S})(::UndefInitializer, dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(undef, dims)
+# TODO Deprecate
 (::Type{<:StringArray})(dims::Integer...) = StringArray{String,length(dims)}(dims)
+(::Type{<:StringArray})(::UndefInitializer, dims::Integer...) = StringArray{String,length(dims)}(undef, dims)
 
 function Base.convert(::Type{<:StringArray{T}}, arr::AbstractArray{<:STR, N}) where {T,N}
-    s = StringArray{T, N}(size(arr))
+    s = StringArray{T, N}(undef, size(arr))
     @inbounds for i in eachindex(arr)
         if _isassigned(arr, i)
             s[i] = arr[i]
@@ -304,7 +323,7 @@ _isassigned(arr, i::CartesianIndex) = isassigned(arr, i.I...)
 end
 
 function Base.similar(a::StringArray, T::Type{<:STR}, dims::Tuple{Vararg{Int64, N}}) where N
-    StringArray{T, N}(dims)
+    StringArray{T, N}(undef, dims)
 end
 
 function Base.empty!(a::StringVector)

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -424,8 +424,9 @@ end
 Base.@deprecate StringArray{T, N}(dims::Tuple{Vararg{Integer}}) where {T,N} StringArray{T, N}(undef, dims)
 Base.@deprecate StringArray{T}(dims::Tuple{Vararg{Integer}}) where {T} StringArray{T}(undef, dims)
 Base.@deprecate StringArray(dims::Tuple{Vararg{Integer}}) StringArray(undef, dims)
-# TODO The following two deprecations don't work, but should be there
-# Base.@deprecate (::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} S(undef, dims)
-# Base.@deprecate (::Type{S})(dims::Integer...) where {S<:StringArray} S(dims...)
+# TODO The following two signatures should either also be deprecated or removed
+# eventually.
+(::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(dims)
+(::Type{<:StringArray})(dims::Integer...) = StringArray{String,length(dims)}(dims)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,7 +136,7 @@ end
     end
 
     @testset "test WeakRefString element type constructor" begin
-        @test eltype(StringVector{WeakRefString}(1)) <: WeakRefString
+        @test eltype(StringVector{WeakRefString}(undef, 1)) <: WeakRefString
     end
 
     @testset "test permute!" begin


### PR DESCRIPTION
I need constructors that have the same signature as the normal ``Array`` constructors for an incoming PR to [TextParse.jl](https://github.com/JuliaComputing/TextParse.jl), plus this generally seems to be the way to go with julia 1.0.

I left the old constructors in there for now because I don't have a good understanding who is using this stuff and what else might need to be updated. Someone else with a better overview of the situation can deprecate them formally in a new PR :)

Would be great if we could merge and tag this so that I can move on with the TextParse.jl PR.

@shashi, can you review this? I believe you wrote the original code?