### PR TITLE
added undef constructor for StringArray

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -266,6 +266,7 @@ function StringArray(dims::Tuple{Vararg{Integer}})
     StringArray{String}(dims)
 end
 
+(::Type{S})(::UndefInitializer, args...) where {S<:StringArray} = S(args...)
 (::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(dims)
 (::Type{<:StringArray})(dims::Integer...) = StringArray{String,length(dims)}(dims)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,4 +163,13 @@ end
         append!(sv2, ["yep", "nope"])
         @test sv2 == ["baz", "qux", "yep", "nope"]
     end
+
+    @testset "constructor" begin
+        sv1 = StringVector(undef, 10)
+        @test eltype(sv1) == String
+        @test size(sv1) == (10,)
+        sv2 = StringVector{WeakRefString}(undef, 10)
+        @test eltype(sv2) == WeakRefString
+        @test size(sv2) == (10,)
+    end
 end


### PR DESCRIPTION
At the moment this constructor is "pirated" in IndexedTables https://github.com/JuliaComputing/IndexedTables.jl/blob/master/src/utils.jl#L24 (to allow generic code to work with `StringArray`) but I think it should live here. At the moment with this PR when IndexedTables is loaded there is a warning that the method is being overwritten there, but I think that's not a big concern: as soon as there's a new tag here we can remove the method from there.