### PR TITLE
Finish #48: switch to Julia 1.0 constructors

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -424,9 +424,8 @@ end
 Base.@deprecate StringArray{T, N}(dims::Tuple{Vararg{Integer}}) where {T,N} StringArray{T, N}(undef, dims)
 Base.@deprecate StringArray{T}(dims::Tuple{Vararg{Integer}}) where {T} StringArray{T}(undef, dims)
 Base.@deprecate StringArray(dims::Tuple{Vararg{Integer}}) StringArray(undef, dims)
-# TODO The following two signatures should either also be deprecated or removed
-# eventually.
-(::Type{S})(dims::Vararg{Integer,N}) where {S<:StringArray{T,N}} where {T,N} = StringArray{T,N}(dims)
-(::Type{<:StringArray})(dims::Integer...) = StringArray{String,length(dims)}(dims)
+Base.@deprecate StringArray{T, N}(dims::Integer...) where {T,N} StringArray{T, N}(undef, dims...)
+Base.@deprecate StringArray{T}(dims::Integer...) where {T} StringArray{T}(undef, dims...)
+Base.@deprecate StringArray(dims::Integer...) StringArray(undef, dims...)
 
 end # module


### PR DESCRIPTION
This builds on top of #48 but deprecates all the old constructors. With this PR checked out I have IndexedTables and JuliaDB tests passing locally.