### PR TITLE
optimize cmp

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -409,6 +409,15 @@ function Base.permute!(arr::StringArray{String}, p::AbstractVector)
     arr
 end
 
+function Base.sortperm(arr::StringArray{String})
+    sortperm(convert(StringArray{WeakRefString{UInt8}}, arr))
+end
+
+function Base.sort!(arr::StringArray{String})
+    permute!(arr, sortperm(arr))
+    arr
+end
+
 function Base.vcat(a::StringVector{T}, b::StringVector{T}) where T
     StringVector{T}(vcat(a.buffer, b.buffer), vcat(a.offsets, b.offsets .+ length(a.buffer)), vcat(a.lengths, b.lengths))
 end

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -48,6 +48,13 @@ function ==(x::String, y::WeakRefString{T}) where {T}
 end
 ==(y::WeakRefString, x::String) = x == y
 
+function Base.cmp(a::WeakRefString{T}, b::WeakRefString{T}) where T
+    al, bl = a.len, b.len
+    c = ccall(:memcmp, Int32, (Ptr{T}, Ptr{T}, Csize_t),
+              a.ptr, b.ptr, min(al,bl))
+    return c < 0 ? -1 : c > 0 ? +1 : cmp(al,bl)
+end
+
 function Base.hash(s::WeakRefString{T}, h::UInt) where {T}
     h += Base.memhash_seed
     ccall(Base.memhash, UInt, (Ptr{T}, Csize_t, UInt32), s.ptr, s.len, h % UInt32) + h

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,9 +95,12 @@ end
         svinit = StringVector{WeakRefString{UInt8}}(sa)
         @testset "version" for sv in (copy(svinit),
                                    copyto!(similar(svinit), svinit),
+                                   convert(StringVector{String}, sa),
                                    StringVector{WeakRefString{UInt8}}(sa))
             @test sa == sv
             @test sort(sa) == sort(sv)
+            @test sortperm(sa) == sortperm(sv)
+            @test sort!(copy(sa)) == sort(sv)
             @test copy(sv) == sv
 
             @testset "setindex with WeakRefString" begin


### PR DESCRIPTION
fixes #55 

```julia
julia> @btime cmp($(sa[1]), $(sa[2]))
  5.647 ns (0 allocations: 0 bytes)
-1
```
Much better now.

Also uses this to optimize `sort` and `sortperm` on `StringArray{String}` avoiding allocation before `cmp`