### PR TITLE
Add some missing mutable operations for StringVector. Addresses https…

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -311,13 +311,13 @@ function _setindex!(arr::StringArray, val::AbstractString, idx)
     val
 end
 
-function _setindex!(arr::StringArray, val::Missing, idx)
+function _setindex!(arr::StringArray{Union{T, Missing}, N}, val::Missing, idx) where {T, N}
     arr.lengths[idx] = 0
     arr.offsets[idx] = MISSING_OFFSET
     val
 end
 
-function _setindex!(arr::StringArray, val::Missing, idx...)
+function _setindex!(arr::StringArray{Union{T, Missing}, N}, val::Missing, idx...) where {T, N}
     arr.lengths[idx...] = 0
     arr.offsets[idx...] = MISSING_OFFSET
     val
@@ -343,7 +343,7 @@ function Base.push!(arr::StringVector, val::AbstractString)
     arr
 end
 
-function Base.push!(arr::StringVector, val::Missing)
+function Base.push!(arr::StringVector{Union{T, Missing}}, val::Missing) where {T}
     push!(arr.offsets, MISSING_OFFSET)
     push!(arr.lengths, 0)
     arr
@@ -364,7 +364,7 @@ function Base.insert!(arr::StringVector, idx::Integer, item::AbstractString)
     arr
 end
 
-function Base.insert!(arr::StringVector, idx::Integer, item::Missing)
+function Base.insert!(arr::StringVector{Union{T, Missing}}, idx::Integer, item::Missing) where {T}
     insert!(arr.offsets, idx, MISSING_OFFSET)
     insert!(arr.lengths, idx, 0)
     arr
@@ -413,6 +413,8 @@ function _deleteat!(a::StringVector, i, len)
     Base._deleteat!(a.lengths, i, len)
     return
 end
+
+const _default_splice = []
 
 function Base.splice!(a::StringVector, i::Integer, ins=_default_splice)
     v = a[i]
@@ -478,10 +480,10 @@ function Base.prepend!(a::StringVector, items::AbstractVector)
     return a
 end
 
-Base.prepend!(a::StringVector, iter) = _prepend!(a, IteratorSize(iter), iter)
+Base.prepend!(a::StringVector, iter) = _prepend!(a, Base.IteratorSize(iter), iter)
 Base.pushfirst!(a::StringVector, iter...) = prepend!(a, iter)
 
-function _prepend!(a, ::Union{HasLength,HasShape}, iter)
+function _prepend!(a, ::Union{Base.HasLength,Base.HasShape}, iter)
     n = length(iter)
     _growbeg!(a, n)
     i = 0
@@ -491,7 +493,7 @@ function _prepend!(a, ::Union{HasLength,HasShape}, iter)
     a
 end
 
-function _prepend!(a, ::IteratorSize, iter)
+function _prepend!(a, ::Base.IteratorSize, iter)
     n = 0
     for item in iter
         n += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,14 @@ end
                 @test sa == sv
             end
 
+            @testset "setindex with missing" begin
+                sv1 = StringVector{String}(["foo", "bar"])
+                @test_throws MethodError setindex!(sv1, missing, 1)
+                sv1 = StringVector{Union{String, Missing}}(["foo", "bar"])
+                sv[1] = missing
+                @test sv[1] === missing
+            end
+
             push!(sv, "🍕") == push!(copy(sa), "🍕")
             @test length(empty!(sv)) == 0
         end
@@ -147,4 +155,74 @@ end
         @test deleteat!(copy(sv2), [1,2]) == []
         @test deleteat!(copy(sv2), 1:2) == []
     end
+
+    @testset "resize!" begin
+        sv1 = StringVector{WeakRefString{UInt8}}(["foo", "bar"])
+        resize!(sv1, 0)
+        @test length(sv1) == 0
+        resize!(sv1, 10)
+        @test length(sv1) == 10
+    end
+
+    @testset "push!" begin
+        sv1 = StringVector{String}(["foo", "bar"])
+        push!(sv1, "hey")
+        @test length(sv1) == 3
+        @test sv1[end] == "hey"
+        @test_throws MethodError push!(sv1, missing)
+        sv1 = StringVector{Union{String, Missing}}(["foo", "bar"])
+        push!(sv1, missing)
+        @test length(sv1) == 3
+        @test sv1[end] === missing
+    end
+
+    @testset "insert!" begin
+        sv1 = StringVector{String}(["foo", "bar"])
+        insert!(sv1, 2, "hey")
+        @test length(sv1) == 3
+        @test sv1[2] == "hey"
+        @test sv1[3] == "bar"
+        @test_throws MethodError insert!(sv1, 2, missing)
+        sv1 = StringVector{Union{String, Missing}}(["foo", "bar"])
+        insert!(sv1, 2, missing)
+        @test sv1[2] === missing
+        @test length(sv1) == 3
+    end
+
+    @testset "splice!" begin
+        sv1 = StringVector{String}(["foo", "bar"])
+        v = splice!(sv1, 2)
+        @test v == "bar"
+        @test length(sv1) == 1
+        push!(sv1, "bar")
+        v = splice!(sv1, 1:2)
+        @test v[1] == "foo"
+        @test v[2] == "bar"
+        @test length(sv1) == 0
+        sv1 = StringVector{String}(["foo", "bar"])
+        v = splice!(sv1, 1:2, ["bar", "foo"])
+        @test sv1 == reverse(v)
+        sv1 = StringVector{String}(["foo", "bar"])
+        v = splice!(sv1, 2, ["foo", "foo", "bar"])
+        @test length(sv1) == 4
+        @test sv1[end] == "bar"
+    end
+
+    @testset "prepend!/pushfirst!/pop!/popfirst!" begin
+        sv1 = StringVector{String}(["foo", "bar"])
+        prepend!(sv1, ["hey", "there"])
+        @test length(sv1) == 4
+        @test sv1[1] == "hey"
+        @test sv1[2] == "there"
+        pushfirst!(sv1, "sailor")
+        @test length(sv1) == 5
+        @test sv1[1] == "sailor"
+        v = popfirst!(sv1)
+        @test v == "sailor"
+        @test length(sv1) == 4
+        v = pop!(sv1)
+        @test v == "bar"
+        @test length(sv1) == 3
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,8 +77,8 @@ end
                 sv1 = StringVector{String}(["foo", "bar"])
                 @test_throws MethodError setindex!(sv1, missing, 1)
                 sv1 = StringVector{Union{String, Missing}}(["foo", "bar"])
-                sv[1] = missing
-                @test sv[1] === missing
+                sv1[1] = missing
+                @test sv1[1] === missing
             end
 
             push!(sv, "🍕") == push!(copy(sa), "🍕")


### PR DESCRIPTION
…://github.com/JuliaData/CSV.jl/issues/435

cc: @nalimilan @bkamins 

I haven't added tests yet, but I think this is coming together. I really think Base should make a bunch of these methods work on AbstractVector and just require mutable AbstractVectors to implement `growat!`, and `deleteat!`, but oh well.