### PR TITLE
use promote_rule not promote_type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.3"
 DataAPI = "1"
 Parsers = "1"
+julia = "1.3"

--- a/src/inlinestrings.jl
+++ b/src/inlinestrings.jl
@@ -23,7 +23,7 @@ const InlineStrings = Union{InlineString1,
                             InlineString127,
                             InlineString255}
 
-function Base.promote_type(::Type{T}, ::Type{S}) where {T <: InlineString, S <: InlineString}
+function Base.promote_rule(::Type{T}, ::Type{S}) where {T <: InlineString, S <: InlineString}
     T === InlineString1 && return S
     S === InlineString1 && return T
     T === InlineString3 && return S
@@ -41,7 +41,7 @@ function Base.promote_type(::Type{T}, ::Type{S}) where {T <: InlineString, S <: 
     return InlineString255
 end
 
-Base.promote_type(::Type{T}, ::Type{String}) where {T <: InlineString} = String
+Base.promote_rule(::Type{T}, ::Type{String}) where {T <: InlineString} = String
 
 Base.widen(::Type{InlineString1}) = InlineString3
 Base.widen(::Type{InlineString3}) = InlineString7

--- a/test/inlinestrings.jl
+++ b/test/inlinestrings.jl
@@ -31,6 +31,10 @@ y = InlineString7(x)
 @test promote_type(InlineString255, InlineString7) === InlineString255
 @test promote_type(InlineString63, InlineString15) === InlineString63
 
+# Ensure we haven't caused ambiguity with Base.
+# https://discourse.julialang.org/t/having-trouble-implementating-a-tables-jl-row-table-when-using-badukgoweiqitools-dataframe-tbl-no-longer-works/63622/1
+@test promote_type(Union{}, String) == String
+
 end # @testset
 
 @testset "InlineString operations" begin


### PR DESCRIPTION
Solves the ambiguity reported in https://discourse.julialang.org/t/having-trouble-implementating-a-tables-jl-row-table-when-using-badukgoweiqitools-dataframe-tbl-no-longer-works/63622
cc @xiaodaigh

I have a feeling that one is not mean to define `promote_type` directly.
(Will be making a PR to Julia to document that and then find out if i am wrong via Cunningham's law)