### PR TITLE
Safer PosLenStrings

### DIFF
--- a/src/poslenstrings.jl
+++ b/src/poslenstrings.jl
@@ -18,11 +18,11 @@ struct PosLenString <: AbstractString
     e::UInt8
     inds::Vector{Int} # only for escaped strings
     
-    @inline function PosLenString(d::Vector{UInt8}, p::PosLen, e::UInt8)
+    @inline function PosLenString(d::AbstractVector{UInt8}, p::PosLen, e::UInt8)
         if p.escapedvalue
-            return new(d, p, e, escapedcodeunits(d, p, e))
+            return new(Vector{UInt8}(d), p, e, escapedcodeunits(d, p, e))
         else
-            return new(d, p, e)
+            return new(Vector{UInt8}(d), p, e)
         end
     end
 end


### PR DESCRIPTION
This is a very naive solution

While trying to update a package to use the latest version of CSV I ran into this error:
```
Test threw exception
  Expression: length(unique(tcol.lazy_data.data.validity)) == 300
  MethodError: no method matching PosLenString(::SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, ::Parsers.PosLen, ::UInt8)
  Closest candidates are:
    PosLenString(::Vector{UInt8}, ::Parsers.PosLen, ::UInt8) at /Users/wynand/.julia/packages/WeakRefStrings/8Efn4/src/poslenstrings.jl:21
  Stacktrace:
    [1] detectcell(buf::SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, pos::Int64, len::Int64, row::Int64, rowoffset::Int64, i::Int64, col::CSV.Column, ctx::CSV.Context, rowsguess::Int64)
      @ CSV ~/.julia/packages/CSV/YCQhi/src/file.jl:740
    [2] parserow
      @ ~/.julia/packages/CSV/YCQhi/src/file.jl:605 [inlined]
    [3] parsefilechunk!(ctx::CSV.Context, buf::SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, pos::Int64, len::Int64, rowsguess::Int64, rowoffset::Int64, columns::Vector{CSV.Column}, TR::Val{false}, #unused#::Type{Tuple{}})
      @ CSV ~/.julia/packages/CSV/YCQhi/src/file.jl:558
    [4] CSV.File(ctx::CSV.Context, chunking::Bool)
      @ CSV ~/.julia/packages/CSV/YCQhi/src/file.jl:365
    [5] File
      @ ~/.julia/packages/CSV/YCQhi/src/file.jl:199 [inlined]
    [6] #File#26
      @ ~/.julia/packages/CSV/YCQhi/src/file.jl:195 [inlined]
    [7] File
      @ ~/.julia/packages/CSV/YCQhi/src/file.jl:194 [inlined]
```

This change assumes that any `AbstractVector{UInt8}` can (and should) be converted to `Vector{UInt8}`, which I'm not sure is a good assumption