### PR TITLE
Be more careful about InlineString creation from memory

### DIFF
--- a/test/inlinestrings.jl
+++ b/test/inlinestrings.jl
@@ -34,6 +34,12 @@ y = InlineString7(x)
 # https://discourse.julialang.org/t/having-trouble-implementating-a-tables-jl-row-table-when-using-badukgoweiqitools-dataframe-tbl-no-longer-works/63622/1
 @test promote_type(Union{}, String) == String
 
+# make sure we don't read past an end of a buffer
+buf = Vector{UInt8}("hey")
+x = InlineString7(buf, 1, 3)
+@test x == "hey"
+@test typeof(x) == InlineString7
+
 end # @testset
 
 @testset "InlineString operations" begin


### PR DESCRIPTION
The issue in the optimized InlineString constructor that took a byte
buffer, byte position, and length was that it assumed it always had
`sizeof(T)` number of bytes it could "reinterpret" as an InlineString,
fiddle the bits and return a valid `T`. But if we're near the end of the
byte buffer, where we're trying to construct a final `InlineString7`,
for example, from the last 5 bytes of the buffer, it's invalid to use
our `unsafe_load` trick because we're reaching past the end of the byte
buffer to reinterpret memory. We already have safe-guards to zero out
that memory when constructing the actual InlineString, but if the byte
buffer doesn't happen to be aligned just right, or we're constructing an
`InlineString255` for example, it's very possible to get a segfault by
touching invalid memory. Luckily, the fix is pretty easy to check that
we _do_ have enough room, and otherwise, just build the InlineString
manually, byte by byte.