### PR TITLE
Define read/write on binary format of InlineStrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "1.2.2"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,16 @@ version = "1.2.2"
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
+[extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataAPI = "1"
 Parsers = "2"
 julia = "1.3"
+
+[targets]
+test = ["Test", "Random", "Serialization"]

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -1,6 +1,6 @@
 module WeakRefStrings
 
-using DataAPI, Parsers, Serialization
+using DataAPI, Parsers
 
 export WeakRefString, WeakRefStringArray, StringArray, StringVector
 export PosLen, PosLenString, PosLenStringVector

--- a/test/inlinestrings.jl
+++ b/test/inlinestrings.jl
@@ -1,4 +1,4 @@
-using Test, WeakRefStrings, Parsers
+using Test, WeakRefStrings, Parsers, Serialization
 import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED, INVALID_QUOTED_FIELD, ESCAPED_STRING, NEWLINE, SUCCESS, peekbyte, incr!, checksentinel, checkdelim, checkcmtemptylines
 
 @testset "InlineString basics" begin

--- a/test/inlinestrings.jl
+++ b/test/inlinestrings.jl
@@ -43,7 +43,7 @@ x = InlineString7(buf, 1, 3)
 end # @testset
 
 @testset "InlineString operations" begin
-    for y in ("",  "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255)
+    for y in ("", "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255)
         x = InlineString(y)
         @show typeof(x)
         @test codeunits(x) == codeunits(y)
@@ -95,6 +95,10 @@ end # @testset
         @test cmp(x, x) == 0
         @test cmp(x, y) == 0
         @test cmp(y, x) == 0
+        io = IOBuffer()
+        write(io, x)
+        seekstart(io)
+        @test read(io, typeof(x)) === x
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using WeakRefStrings, Test, Random, Parsers, Serialization
+using WeakRefStrings, Test, Random, Parsers
 using DataAPI: refarray, refvalue
 
 include("poslenstrings.jl")


### PR DESCRIPTION
Fixes #81. Also removes the need for explicit serialization overloads.
The only hesitation in this approach was the difference from how regular
Strings work, but the Base docs are pretty clear that read/write are for
the "binary" layout of types, while `print` is for a textual
representation.