### PR TITLE
Ensure string(::PosLenString) returns String

### DIFF
--- a/src/poslenstrings.jl
+++ b/src/poslenstrings.jl
@@ -169,7 +169,7 @@ end
 end
 
 const BaseStrs = Union{Char, String, SubString{String}}
-Base.string(a::PosLenString) = a
+Base.string(a::PosLenString) = String(a)
 Base.string(a::PosLenString...) = _string(a...)
 Base.string(a::BaseStrs, b::PosLenString) = _string(a, b)
 Base.string(a::BaseStrs, b::BaseStrs, c::PosLenString) = _string(a, b, c)

--- a/test/poslenstrings.jl
+++ b/test/poslenstrings.jl
@@ -115,4 +115,8 @@ x = strs(["hey", "there", "sailor", "esc\"aped"], UInt8('"'))
 @test isassigned(x, 1)
 @test x[1:3] == ["hey", "there", "sailor"]
 
+# https://github.com/JuliaData/InlineStrings.jl/issues/2
+x = str("hey")
+@test typeof(string(x)) == String
+
 end


### PR DESCRIPTION
Fixes the type instability issue mentioned in
https://github.com/JuliaData/InlineStrings.jl/issues/2.