### PR TITLE
added isassigned method for StringArray to avoid disastrous try/catch fallback

### DIFF
--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -269,6 +269,10 @@ _isassigned(arr, i::CartesianIndex) = isassigned(arr, i.I...)
     convert(T, WeakRefString(pointer(a.buffer) + offset, a.lengths[i...]))
 end
 
+function Base.isassigned(a::StringArray, i::Integer...)
+    a.offsets[i...] ≢ UNDEF_OFFSET
+end
+
 function Base.similar(a::StringArray, T::Type{<:STR}, dims::Tuple{Vararg{Int64, N}}) where N
     StringArray{T, N}(undef, dims)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,15 @@ end
         @test length(sv1) == 3
     end
 
+    @testset "isassigned" begin
+        sv = StringVector{Union{String,Missing}}(undef, 3)
+        sv[1] = "foo"
+        sv[2] = "bar"
+        @test isassigned(sv, 1)
+        @test isassigned(sv, 2)
+        @test !isassigned(sv, 3)
+    end
+
     @testset "DataAPI" begin
         a = StringVector(["a", "b", "c"])
         v = refarray(a)


### PR DESCRIPTION
The `AbstractArray` fallback for `Base.isassigned` relies on a `try`/`catch` and is unbelievably slow.

This PR adds a method for `StringArray` to avoid this along with some tests.