### PR TITLE
Make clear Parsers.jl only required for PosLen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /deps/builds
 /deps/usr
 CMakeLists.txt.user
+/Manifest.toml

--- a/src/WeakRefStrings.jl
+++ b/src/WeakRefStrings.jl
@@ -1,6 +1,7 @@
 module WeakRefStrings
 
-using DataAPI, Parsers
+using DataAPI
+using Parsers: PosLen
 
 export WeakRefString, WeakRefStringArray, StringArray, StringVector
 export PosLen, PosLenString, PosLenStringVector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using WeakRefStrings, Test, Random, Parsers, InlineStrings
+using WeakRefStrings, Test, Random, InlineStrings
 using DataAPI: refarray, refvalue
+using Parsers: PosLen
 
 include("poslenstrings.jl")
 


### PR DESCRIPTION
- No functional changes
- I was just auditting which packages depend on Parsers.jl directly, and it took me a while to see how this package was using it 